### PR TITLE
[WIP] feat: add method to obtain placeholders

### DIFF
--- a/api/src/main/java/io/github/miniplaceholders/api/Expansion.java
+++ b/api/src/main/java/io/github/miniplaceholders/api/Expansion.java
@@ -1,11 +1,13 @@
 package io.github.miniplaceholders.api;
 
+import io.github.miniplaceholders.api.enums.DisplayType;
 import io.github.miniplaceholders.api.placeholder.AudiencePlaceholder;
 import io.github.miniplaceholders.api.placeholder.RelationalPlaceholder;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -107,6 +109,11 @@ public sealed interface Expansion permits ExpansionImpl {
      * @since 2.1.0
      */
     boolean registered();
+
+    // Start get by name - https://github.com/MiniPlaceholders/MiniPlaceholders/issues/174
+    Collection<String> audiencePlaceholdersByName();
+
+    Collection<String> audiencePlaceholders(final DisplayType type); // different name?
 
     /**
      * Creates a new Expansion Builder

--- a/api/src/main/java/io/github/miniplaceholders/api/ExpansionImpl.java
+++ b/api/src/main/java/io/github/miniplaceholders/api/ExpansionImpl.java
@@ -1,5 +1,6 @@
 package io.github.miniplaceholders.api;
 
+import io.github.miniplaceholders.api.enums.DisplayType;
 import io.github.miniplaceholders.api.placeholder.AudiencePlaceholder;
 import io.github.miniplaceholders.api.placeholder.RelationalPlaceholder;
 import net.kyori.adventure.audience.Audience;
@@ -144,6 +145,29 @@ final class ExpansionImpl implements Expansion {
     @Override
     public boolean registered() {
         return MiniPlaceholders.expansions.contains(this);
+    }
+
+    @Override
+    public Collection<String> audiencePlaceholdersByName() {
+        final List<String> list = new ArrayList<>(audiencePlaceholders.length);
+        for (final Tags.Single audience : this.audiencePlaceholders) {
+            list.add(Tags.formatPlaceholder(audience.key));
+        }
+
+        return list;
+    }
+
+    @Override
+    public Collection<String> audiencePlaceholders(final DisplayType displayType) {
+        final List<String> list = new ArrayList<>(audiencePlaceholders.length);
+        for (final Tags.Single audience : this.audiencePlaceholders) {
+            switch(displayType) {
+                case RAW -> list.add(audience.key);
+                case PLACEHOLDER ->  list.add(Tags.formatPlaceholder(audience.key));
+            }
+        }
+
+        return list;
     }
 
     static final class Builder implements Expansion.Builder {

--- a/api/src/main/java/io/github/miniplaceholders/api/Tags.java
+++ b/api/src/main/java/io/github/miniplaceholders/api/Tags.java
@@ -25,9 +25,13 @@ final class Tags {
         return new Single(name, audiencePlaceholder);
     }
 
+    static String formatPlaceholder(@NotNull final String key) {
+        return "<%s>".formatted(key);
+    }
+
     static final class Relational {
         private final RelationalPlaceholder relationalPlaceholder;
-        private final String key;
+        final String key;
 
         Relational(final String key, final RelationalPlaceholder relationalPlaceholder){
             this.relationalPlaceholder = relationalPlaceholder;
@@ -67,7 +71,7 @@ final class Tags {
 
     static final class Single {
         private final AudiencePlaceholder audiencePlaceholder;
-        private final String key;
+        final String key;
 
         private Single(@NotNull final String key, @NotNull final AudiencePlaceholder audiencePlaceholder){
             this.key = key;

--- a/api/src/main/java/io/github/miniplaceholders/api/enums/DisplayType.java
+++ b/api/src/main/java/io/github/miniplaceholders/api/enums/DisplayType.java
@@ -1,0 +1,7 @@
+package io.github.miniplaceholders.api.enums;
+
+public enum DisplayType {
+
+    RAW,
+    PLACEHOLDER
+}

--- a/api/src/test/java/io/github/miniplaceholders/test/ExpansionsTest.java
+++ b/api/src/test/java/io/github/miniplaceholders/test/ExpansionsTest.java
@@ -1,6 +1,8 @@
 package io.github.miniplaceholders.test;
 
 import io.github.miniplaceholders.api.Expansion;
+import io.github.miniplaceholders.api.enums.DisplayType;
+import io.github.miniplaceholders.api.placeholder.AudiencePlaceholder;
 import io.github.miniplaceholders.api.utils.TagsUtils;
 import io.github.miniplaceholders.test.testobjects.TestAudienceHolder;
 import net.kyori.adventure.text.Component;
@@ -41,5 +43,18 @@ class ExpansionsTest {
         );
 
         assertContentEquals(result, Component.text("<test_testing>"));
+    }
+
+    @Test
+    void testGetAudiencePlaceholdersByName() {
+        TestAudienceHolder audience = new TestAudienceHolder(null);
+
+        final Expansion expansion = Expansion.builder("test")
+                .audiencePlaceholder("test", TagsUtils.NULL_AUDIENCE_PLACEHOLDER)
+                .build();
+
+        System.out.println(expansion.audiencePlaceholdersByName());
+        System.out.println(expansion.audiencePlaceholders(DisplayType.PLACEHOLDER));
+        System.out.println(expansion.audiencePlaceholders(DisplayType.RAW));
     }
 }


### PR DESCRIPTION
Would close #174.

The 2nd method I added with the DisplayType enum, would mean less methods which imo is a bit cleaner and might be a better name then `audiencePlaceholdersByNameRaw`



