### PR TITLE
Update Cloud maven repository URL

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,21 +18,26 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            name = "sonatype-snapshots"
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
         maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://repo.maven.apache.org/maven2/")
+        maven("https://repo.spongepowered.org/repository/")
         maven("https://jitpack.io") {
             mavenContent {
                 includeGroup("net.william278")
             }
         }
-        maven("https://oss.sonatype.org/content/repositories/snapshots")
         maven("https://repo.jpenilla.xyz/snapshots/")
     }
 }
 
 plugins {
     id("quiet-fabric-loom") version "1.10.316"
-    id("org.spongepowered.gradle.plugin") version "2.3.0" // sponge is disabled
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 

--- a/sponge/build.gradle.kts
+++ b/sponge/build.gradle.kts
@@ -4,7 +4,7 @@ import org.spongepowered.plugin.metadata.model.PluginDependency
 plugins {
     id("miniplaceholders.auto.module")
     id("miniplaceholders.shadow")
-    id("org.spongepowered.gradle.plugin")
+    id("org.spongepowered.gradle.plugin") version "2.3.0"
 }
 
 dependencies {
@@ -17,6 +17,7 @@ dependencies {
 }
 
 sponge {
+    injectRepositories(false)
     apiVersion("8.1.0")
     license("GPL-3")
     loader {


### PR DESCRIPTION
The current `cloud-paper` snapshot version doesn't work properly on Paper 1.21.6. A newer snapshot was released that fixes this issue. This PR updates the snapshot maven repository URL to the new one containing the fixed version.

SpongeGradle was injecting their repository to be the first one, which resulted to an older cloud-paper snapshot being downloaded. I worked around this by manually defining the sponge maven repository and removing the sponge gradle plugin from the `settings.gradle.kts` file.

I've tested this on Paper and confirmed that MiniPlaceholders now starts up without errors on 1.21.6 Paper.